### PR TITLE
diff: list only changed, added and modified files

### DIFF
--- a/src/lint-diff.js
+++ b/src/lint-diff.js
@@ -30,7 +30,7 @@ const linter = new CLIEngine()
 const formatter = linter.getFormatter()
 
 const getChangedFiles = pipeP(
-  commitRange => exec('git', ['diff', commitRange, '--name-only']),
+  commitRange => exec('git', ['diff', commitRange, '--name-only', '--diff-filter=ACM']),
   prop('stdout'),
   split('\n'),
   filter(endsWith('.js')),


### PR DESCRIPTION
Use --diff-filter=ACM option to `git diff` command in order to only list
Added (A), Changed (C) and Modified (M) files.

This closes #3 