### PR TITLE
Count errors and warnings just for changed lines

### DIFF
--- a/src/lint-diff.js
+++ b/src/lint-diff.js
@@ -13,7 +13,9 @@ import {
   equals,
   filter,
   find,
+  length,
   map,
+  merge,
   objOf,
   pipe,
   pipeP,
@@ -65,9 +67,28 @@ const filterLinterMessages = changedFileLineMap => (linterOutput) => {
     return filterMessages(result)
   }
 
+  const countBySeverity = severity =>
+    pipe(
+      filter(propEq('severity', severity)),
+      length
+    )
+
+  const countWarningMessages = countBySeverity(1)
+
+  const warningCount = (result) => {
+    const transform = {
+      warningCount: countWarningMessages(result.messages),
+    }
+
+    return merge(result, transform)
+  }
+
   return pipe(
     prop('results'),
-    map(filterMessagesByFile),
+    map(pipe(
+      filterMessagesByFile,
+      warningCount
+    )),
     objOf('results')
   )(linterOutput)
 }

--- a/src/lint-diff.js
+++ b/src/lint-diff.js
@@ -74,6 +74,7 @@ const filterLinterMessages = changedFileLineMap => (linterOutput) => {
     )
 
   const countWarningMessages = countBySeverity(1)
+  const countErrorMessages = countBySeverity(2)
 
   const warningCount = (result) => {
     const transform = {
@@ -83,11 +84,20 @@ const filterLinterMessages = changedFileLineMap => (linterOutput) => {
     return merge(result, transform)
   }
 
+  const errorCount = (result) => {
+    const transform = {
+      errorCount: countErrorMessages(result.messages),
+    }
+
+    return merge(result, transform)
+  }
+
   return pipe(
     prop('results'),
     map(pipe(
       filterMessagesByFile,
-      warningCount
+      warningCount,
+      errorCount
     )),
     objOf('results')
   )(linterOutput)


### PR DESCRIPTION
Fix the error and warning counts to consider just changed lines and not the whole file.

closes https://github.com/grvcoelho/lint-diff/issues/7