### PR TITLE
chore: bump webpack and webpack-cli dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "eslint": "^4.7.2",
     "eslint-config-pagarme-base": "^2.0.0",
     "eslint-plugin-import": "^2.7.0",
-    "webpack": "^4.5.0",
-    "webpack-cli": "^2.0.14",
+    "webpack": "4.30.0",
+    "webpack-cli": "3.3.1",
     "webpack-node-externals": "^1.7.2"
   },
   "dependencies": {


### PR DESCRIPTION
It is necessary to fix the error `Cannot read property 'properties' of undefined`

https://github.com/plotly/dash-component-boilerplate/issues/12#issuecomment-425040481